### PR TITLE
[ci skip] [skip ci] ***NO_CI*** Update maintainers, remove conda-forge/napari team

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
-* [@conda-forge/napari](https://github.com/conda-forge/napari/)
+* [@goanpeca](https://github.com/goanpeca/)
+* [@jaimergp](https://github.com/jaimergp/)
 * [@thewtex](https://github.com/thewtex/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,5 +43,6 @@ about:
 
 extra:
   recipe-maintainers:
-    - conda-forge/napari
+    - goanpeca
+    - jaimergp
     - thewtex


### PR DESCRIPTION
The `conda-forge/napari` team was initially added as a way to support the migration to conda-forge.

The situation is now stable and we can prevent unwanted notifications by only leaving a subset of the team listed explicitly as maintainers.